### PR TITLE
```

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -37,11 +37,8 @@ services:
   acestream-arm:
     image: jopsis/acestream:arm64
     container_name: acestream-arm
-    privileged: true
-    restart: unless-stopped
     network_mode: "host"
-    ports:
-      - "6878:6878"
+    restart: unless-stopped
     environment:
       - TZ=Europe/Madrid
         - ACESTREAM_REMOTE=yes
@@ -64,5 +61,3 @@ services:
 #      - ACESTREAM_REMOTE=yes        # Permite acceso remoto
 #    volumes:
 #      - ./acestream-config:/acestream.engine
-#    networks:
-#      - walactv-network


### PR DESCRIPTION
refactor(docker): Simplificar configuración del servicio acestream-arm

Se eliminaron opciones redundantes del servicio 'acestream-arm'. 'privileged: true' y el mapeo de puertos son innecesarios al usar 'network_mode: "host"', optimizando la configuración del contenedor.
```